### PR TITLE
Fixing test

### DIFF
--- a/AeViz/utils/decorators/grid.py
+++ b/AeViz/utils/decorators/grid.py
@@ -70,7 +70,7 @@ def get_grid(func):
                                      args[0].cell.dphi(args[0].ghost)[:, None, None]),
                                      **{X.name: X, Y.name: Y}))
         else:
-            raise TypeError(f'plane type {kwargs['plane']} not recognized')
+            raise TypeError(f"plane type {kwargs['plane']} not recognized")
         if len(outdata) == 1:
             return outdata[0]
         else:

--- a/bin/run_comparison
+++ b/bin/run_comparison
@@ -73,10 +73,13 @@ for q in ['entropy', 'rho', 'gas_pressure', 'temperature']:
     att = getattr(ae, q)
     # Let's plot
     att(args.tr, plane='radius', color=COLOURS[i_s])
+  if q == 'gas_pressure':
+    ae.ylim([1e22, 1e30])
 
   ae.update_legend(sims)
   ae.title('Time = %.1f s' % args.tr)
   ae.save_plot('%s_r.pdf' % q, savedir=args.savedir, kwargs_savefig={'bbox_inches' : 'tight'})
+  ae.save_plot('%s_r.png' % q, savedir=args.savedir, kwargs_savefig={'bbox_inches' : 'tight'})
   ae.Close()
 
 # 2D plots - Time

--- a/bin/run_comparison
+++ b/bin/run_comparison
@@ -78,8 +78,10 @@ for q in ['entropy', 'rho', 'gas_pressure', 'temperature']:
 
   ae.update_legend(sims)
   ae.title('Time = %.1f s' % args.tr)
-  ae.save_plot('%s_r.pdf' % q, savedir=args.savedir, kwargs_savefig={'bbox_inches' : 'tight'})
-  ae.save_plot('%s_r.png' % q, savedir=args.savedir, kwargs_savefig={'bbox_inches' : 'tight'})
+  ae.save_plot('%s_r.pdf' % q, savedir=args.savedir, \
+               kwargs_savefig={'bbox_inches' : 'tight'})
+  ae.save_plot('%s_r.png' % q, savedir=args.savedir, \
+               kwargs_savefig={'bbox_inches' : 'tight'})
   ae.Close()
 
 # 2D plots - Time


### PR DESCRIPTION
Fixing a small problem in line 73 of AeViz/utils/decorators/grid.py that was causing the test to fail. In a TypeError message, single quatations were used for bot the string and the element of the dictionary, causing a problem. The fix was to go from this
```
raise TypeError(f'plane type {kwargs['plane']} not recognized')
```
to this
```
raise TypeError(f"plane type {kwargs['plane']} not recognized")
```
Now the basic test works for all the version of Python.

Also, minor changes.
