### PR TITLE
Added GWs strain partial division in 2 and 3D

### DIFF
--- a/AeViz/plot_utils/figure_utils.py
+++ b/AeViz/plot_utils/figure_utils.py
@@ -91,10 +91,19 @@ def return_positioning(number, form_factor):
                         },
                     5: {
                         1:"""A..
-                             B..
-                             C..
-                             D..
-                             E.e"""
+                             E.e""",
+                        2: """A..
+                              B..
+                              E.e""",
+                        3: """A..
+                              B..
+                              C..
+                              E.e""",
+                        4: """A..
+                              B..
+                              C..
+                              D..
+                              E.e""",
                         }
                     }
     
@@ -124,7 +133,11 @@ def return_positioning(number, form_factor):
                        5: [0.08, 0.2, 1, 0.2, 1, 0.1, 0.08],
                        6: [0.08, 0.4, 1.1, 0.4, 1.1, 0.4, 0.08],
                        7: [1.1, 0.4, 1.1]},
-                    5: {1: [1, 0.03, 0.04]}}
+                    5: {1: [1, 0.03, 0.04],
+                        2: [1, 0.03, 0.04],
+                        3: [1, 0.03, 0.04],
+                        4: [1, 0.03, 0.04],
+                        }}
     
     height_ratio = {1: {1: [1],
                         2: [1],
@@ -151,15 +164,18 @@ def return_positioning(number, form_factor):
                         5: [0.25, 0.75, 0.2, 0.25, 0.75],
                         6: [1, 0.2, 1],
                         7: [0.5, 0.5, 0.25, 0.5, 0.5],},
-                    5: {1: [0.5, 0.5, 0.5, 0.5, 2]}}
-    
-    if form_factor == 4:
+                    5: {1: [0.5, 2],
+                        2: [0.5, 0.5, 2],
+                        3: [0.5, 0.5, 0.5, 2],
+                        4: [0.5, 0.5, 0.5, 0.5, 2],
+                        }}
+    if form_factor == 4 and number != 5:
         gs_kw = {"wspace": 0,
                  "hspace": 0.2}
     elif number == 6:
         gs_kw = {"wspace": 0,
                  "hspace": 0}
-    elif '.' in positioning[number][form_factor] or form_factor == 7:
+    elif '.' in positioning[number][form_factor] or form_factor in [7, 5]:
         gs_kw = {"wspace": 0,
                  "hspace": 0}
     else:
@@ -208,7 +224,11 @@ def return_fig_size(number, form_factor):
                     5: (12, 12),
                     6: (8, 11.6),
                     7: (8, 11.6)},
-                5: {1: (9, 16)}}
+                5: {1: (9, 10),
+                    2: (9, 12),
+                    3: (9, 14),
+                    4: (9, 16),
+                    }}
     
     if number == 6:
         return (9, form_factor*4)

--- a/AeViz/plot_utils/plot_creation.py
+++ b/AeViz/plot_utils/plot_creation.py
@@ -118,22 +118,18 @@ class PlotCreation(object):
                     self.__share_axis(self.axd["B"], [self.axd["D"]], False,
                                       True)
                 elif self.form_factor == 5:
-                    for ax_letter in self.axd:
-                        self.__share_axis(self.axd["A"], [self.axd["B"], 
-                                                          self.axd["C"],
-                                                          self.axd["D"],
-                                                          self.axd["E"],
-                                                          self.axd["F"],
-                                                          self.axd["G"],
-                                                          self.axd["H"]],
-                                          True, False)
-            elif self.number == 5:
-                if self.form_factor == 1:
                     self.__share_axis(self.axd["A"], [self.axd["B"], 
                                                       self.axd["C"],
                                                       self.axd["D"],
-                                                      self.axd["E"]],
+                                                      self.axd["E"],
+                                                      self.axd["F"],
+                                                      self.axd["G"],
+                                                      self.axd["H"]],
                                       True, False)
+            elif self.number == 5:
+                axes_to_share = [self.axd[ax_letter] for ax_letter in self.axd 
+                                  if (not ax_letter.islower() and ax_letter != 'A')]
+                self.__share_axis(self.axd["A"], axes_to_share, True, False)
             elif self.number == 6:
                 sharing = [self.axd[f'IMF{i}'] for i in range(1, form_factor+1)]
                 self.__share_axis(self.axd['full'], sharing, True, False)
@@ -238,23 +234,14 @@ class PlotCreation(object):
             self.axd["B"].yaxis.set_label_position('left')
             self.axd["C"].yaxis.set_label_position('right')
             self.axd["D"].yaxis.set_label_position('right')
-        elif self.number == 5 and self.form_factor == 1:
-            self.axd["A"].tick_params(top=False, labeltop=False,
-                                      bottom=False, labelbottom=False,
-                                      left=True, labelleft=True,
-                                      right=False, labelright=False)
-            self.axd["B"].tick_params(top=False, labeltop=False,
-                                      bottom=False, labelbottom=False,
-                                      left=True, labelleft=True,
-                                      right=False, labelright=False)
-            self.axd["C"].tick_params(top=False, labeltop=False,
-                                      bottom=False, labelbottom=False,
-                                      left=True, labelleft=True,
-                                      right=False, labelright=False)
-            self.axd["D"].tick_params(top=False, labeltop=False,
-                                      bottom=True, labelbottom=True,
-                                      left=True, labelleft=True,
-                                      right=False, labelright=False)
+        elif self.number == 5:
+            for ax_letter in self.axd:
+                if ax_letter in ['E', 'e']:
+                    continue
+                self.axd[ax_letter].tick_params(top=False, labeltop=False,
+                                          bottom=False, labelbottom=False,
+                                          left=True, labelleft=True,
+                                          right=False, labelright=False)
         elif self.number == 6:
             self.axd['full'].tick_params(top=False, labeltop=False,
                                          bottom=False, labelbottom=False,

--- a/AeViz/quantities_plotting/plotting.py
+++ b/AeViz/quantities_plotting/plotting.py
@@ -426,7 +426,6 @@ class Plotting(PlottingUtils, Data):
         radii = [r for r in radii if r is not None]
         self._PlotCreation__setup_axd(5, int(count+1))
         AE220, oth  = self._Data__get_data_from_name(name=qt, file=None, **kwargs)
-        f_h, nuc_h, conv_h, out_h = oth
         letters = ['A', 'B', 'C', 'D']
         for i in range(count+1):
             kwargs['color'] = f'C{i}'
@@ -441,9 +440,9 @@ class Plotting(PlottingUtils, Data):
                                                 )
             kwargs.pop('color')
             self._PlottingUtils__plot1D(letters[i])
-            self.ylim(oth[0].data.limits, letters[i])
-            self.Yscale(oth[0].data.log, letters[i])
-            self.Xscale(oth[0].time.log, letters[i])
+            self.ylim(oth[i].data.limits, letters[i])
+            self.Yscale(oth[i].data.log, letters[i])
+            self.Xscale(oth[i].time.log, letters[i])
 
         self._PlottingUtils__update_params(
                                             ax_letter='E',

--- a/AeViz/simulation/methods/GWs.py
+++ b/AeViz/simulation/methods/GWs.py
@@ -271,7 +271,7 @@ def hydro_strain(self, tob_corrected=True, D=None, theta=np.pi/2, phi=0,
     if self.dim == 1:
         return None
     elif self.dim == 2:
-        return calculate_h(self, D, theta, phi, save_checkpoints)
+        return calculate_h(self, D, theta, phi, save_checkpoints, **kwargs)
     elif self.dim == 3:
         if comp is None:
             return calculate_h(self, D, theta, phi, save_checkpoints)

--- a/AeViz/simulation/methods/GWs.py
+++ b/AeViz/simulation/methods/GWs.py
@@ -274,15 +274,15 @@ def hydro_strain(self, tob_corrected=True, D=None, theta=np.pi/2, phi=0,
         return calculate_h(self, D, theta, phi, save_checkpoints, **kwargs)
     elif self.dim == 3:
         if comp is None:
-            return calculate_h(self, D, theta, phi, save_checkpoints)
+            return calculate_h(self, D, theta, phi, save_checkpoints, **kwargs)
         elif comp == 'h+eq':
-            return calculate_h(self, D, np.pi/2, 0, save_checkpoints)[0:2]
+            return calculate_h(self, D, np.pi/2, 0, save_checkpoints, **kwargs)[0:2]
         elif comp == 'hxeq':
-            return calculate_h(self, D, np.pi/2, 0, save_checkpoints)[2:]
+            return calculate_h(self, D, np.pi/2, 0, save_checkpoints, **kwargs)[2:]
         elif comp == 'h+pol':
-            return calculate_h(self, D, np.pi, 0, save_checkpoints)[:2]
+            return calculate_h(self, D, np.pi, 0, save_checkpoints, **kwargs)[:2]
         elif comp == 'hxpol':
-            return calculate_h(self, D, np.pi, 0, save_checkpoints)[2:]
+            return calculate_h(self, D, np.pi, 0, save_checkpoints, **kwargs)[2:]
 
 def ASD(self, detector, **kwargs):
     """

--- a/bin/create_EEMD
+++ b/bin/create_EEMD
@@ -97,6 +97,8 @@ args.nres = nres
 time = GWs.time.value
 strain = GWs.data.value
 
+print('Starting computation')
+
 for res in range(start, args.nsplits):
     ## SET THE NOISE SEED
     if args.seed is not None:
@@ -117,3 +119,4 @@ for res in range(start, args.nsplits):
     print('Saving %d realizations' % nres)
     
 compact_IMFs(sim.storage_path, args.strain, files)
+print('Done')


### PR DESCRIPTION
Now the partial strains can be computed in up to three regions in which the correction is then applied.
**What's new**
Three regions are now supported by adding the keyword when calling the method.

_New keywords_: `r1`, `r2` and `r3` for the regions.

_Supported values_: each of the region can be delimited by a radius e.g. `PNS_radius` (by adding `avg`, `min`or `max`  delimited by an hyphen one can select the radius type) or by selecting a distance from the center, e.g. 1e8

_How the regions work_: the regions extend from 0 to r1, r1 to r2, and finally r2 to r3.

**What's changed**
The default output is now just the 2D map with the complete strain, without any decomposition.