### PR TITLE
Finite differences

### DIFF
--- a/AeViz/simulation/methods/__init__.py
+++ b/AeViz/simulation/methods/__init__.py
@@ -2,7 +2,8 @@ from AeViz.units import u
 from AeViz.units.constants import constants as c
 from AeViz.units.aeseries import aerray, aeseries
 from AeViz.utils.decorators.simulation import (smooth, derive, hdf_isopen,
-                                        subtract_tob, sum_tob, mask_points)
+                                        subtract_tob, sum_tob, mask_points,
+                                        finite_differences)
 from AeViz.utils.decorators.grid import get_grid, get_radius
 import numpy as np
 from typing import Literal

--- a/AeViz/simulation/methods/composition.py
+++ b/AeViz/simulation/methods/composition.py
@@ -14,6 +14,7 @@ imported into the Simulation class.
 @mask_points
 @smooth
 @derive
+@finite_differences
 @hdf_isopen
 def Ye(self, file_name, **kwargs):
     data = aerray(self.ghost.remove_ghost_cells(np.squeeze(
@@ -27,6 +28,7 @@ def Ye(self, file_name, **kwargs):
 @mask_points
 @smooth
 @derive
+@finite_differences
 @hdf_isopen
 def neutron_fraction(self, file_name, **kwargs):
     data = self.ghost.remove_ghost_cells(np.squeeze(
@@ -39,6 +41,7 @@ def neutron_fraction(self, file_name, **kwargs):
 @mask_points
 @smooth
 @derive
+@finite_differences
 @hdf_isopen
 def proton_fraction(self, file_name, **kwargs):
     data = self.ghost.remove_ghost_cells(np.squeeze(
@@ -51,6 +54,7 @@ def proton_fraction(self, file_name, **kwargs):
 @mask_points
 @smooth
 @derive
+@finite_differences
 @hdf_isopen
 def alpha_fraction(self, file_name, **kwargs):
     data = self.ghost.remove_ghost_cells(np.squeeze(
@@ -63,6 +67,7 @@ def alpha_fraction(self, file_name, **kwargs):
 @mask_points
 @smooth
 @derive
+@finite_differences
 @hdf_isopen
 def heavy_fraction(self, file_name, **kwargs):
     data = self.ghost.remove_ghost_cells(np.squeeze(
@@ -75,6 +80,7 @@ def heavy_fraction(self, file_name, **kwargs):
 @mask_points
 @smooth
 @derive
+@finite_differences
 @hdf_isopen
 def Abar(self, file_name, **kwargs):
     data = self.ghost.remove_ghost_cells(np.squeeze(
@@ -87,6 +93,7 @@ def Abar(self, file_name, **kwargs):
 @mask_points
 @smooth
 @derive
+@finite_differences
 @hdf_isopen
 def Zbar(self, file_name, **kwargs):
     data = self.ghost.remove_ghost_cells(np.squeeze(
@@ -100,6 +107,7 @@ def Zbar(self, file_name, **kwargs):
 @mask_points
 @smooth
 @derive
+@finite_differences
 @hdf_isopen
 def electron_chemical_potential(self, file_name, **kwargs):
     data = self.ghost.remove_ghost_cells(np.squeeze(
@@ -112,6 +120,7 @@ def electron_chemical_potential(self, file_name, **kwargs):
 @mask_points
 @smooth
 @derive
+@finite_differences
 @hdf_isopen
 def neutron_chemical_potential(self, file_name, **kwargs):
     data = self.ghost.remove_ghost_cells(np.squeeze(
@@ -124,6 +133,7 @@ def neutron_chemical_potential(self, file_name, **kwargs):
 @mask_points
 @smooth
 @derive
+@finite_differences
 @hdf_isopen
 def proton_chemical_potential(self, file_name, **kwargs):
     data = self.ghost.remove_ghost_cells(np.squeeze(
@@ -136,6 +146,7 @@ def proton_chemical_potential(self, file_name, **kwargs):
 @mask_points
 @smooth
 @derive
+@finite_differences
 @hdf_isopen
 def neutrino_chemical_potential(self, file_name, **kwargs):
     data = self.ghost.remove_ghost_cells(np.squeeze(

--- a/AeViz/simulation/methods/hydro.py
+++ b/AeViz/simulation/methods/hydro.py
@@ -15,6 +15,7 @@ of the Simulation class
 @mask_points
 @smooth
 @derive
+@finite_differences
 @hdf_isopen
 def rho(self, file_name, **kwargs):
     data = self.ghost.remove_ghost_cells(np.squeeze(
@@ -37,6 +38,7 @@ def mass(self, file_name, **kwargs):
 ## ENERGY
 @get_grid
 @smooth
+@finite_differences
 @hdf_isopen
 def MHD_energy(self, file_name, **kwargs):
     data = self.ghost.remove_ghost_cells(np.squeeze(
@@ -47,6 +49,7 @@ def MHD_energy(self, file_name, **kwargs):
 
 @get_grid
 @smooth
+@finite_differences
 @hdf_isopen
 def rotational_energy(self, file_name, **kwargs):
     data = self.rho(file_name) * self.phi_velocity(file_name) ** 2 * 0.5
@@ -57,6 +60,7 @@ def rotational_energy(self, file_name, **kwargs):
 
 @get_grid
 @smooth
+@finite_differences
 @hdf_isopen
 def kinetic_energy(self, file_name, comp:Literal['tot', 'r', 'th', 'ph']='tot',
                    **kwargs):
@@ -74,7 +78,7 @@ def kinetic_energy(self, file_name, comp:Literal['tot', 'r', 'th', 'ph']='tot',
     elif comp == 'ph':
         v = self.phi_velocity(file_name) ** 2
         label=r'$E_{\mathrm{kin},\phi}$'
-    data = self.rho(file_name) * self._velocity(file_name) ** 2 * 0.5
+    data = self.rho(file_name) * v ** 2 * 0.5
     data.to(u.erg / u.cm**3)
     data.set(name='kin_ene', label=label, cmap='turbo', log=True,
              limits=[1e24, 1e35])
@@ -85,6 +89,7 @@ def kinetic_energy(self, file_name, comp:Literal['tot', 'r', 'th', 'ph']='tot',
 @mask_points
 @smooth
 @derive
+@finite_differences
 @hdf_isopen
 def radial_velocity(self, file_name, **kwargs):
     if self.relativistic:
@@ -101,6 +106,7 @@ def radial_velocity(self, file_name, **kwargs):
 @mask_points
 @smooth
 @derive
+@finite_differences
 @hdf_isopen
 def theta_velocity(self, file_name, **kwargs):
     if self.relativistic:
@@ -117,6 +123,7 @@ def theta_velocity(self, file_name, **kwargs):
 @mask_points
 @smooth
 @derive
+@finite_differences
 @hdf_isopen
 def phi_velocity(self, file_name, **kwargs):
     if self.relativistic:
@@ -134,6 +141,7 @@ def phi_velocity(self, file_name, **kwargs):
 @mask_points
 @smooth
 @derive
+@finite_differences
 @hdf_isopen
 def soundspeed(self, file_name, **kwargs):
     data = self.ghost.remove_ghost_cells(np.squeeze(
@@ -145,6 +153,7 @@ def soundspeed(self, file_name, **kwargs):
 @get_grid
 @mask_points
 @smooth
+@finite_differences
 @derive
 def omega(self, file_name, **kwargs):
     assert self.dim in [2, 3], "No rotational velocity in 1D"

--- a/AeViz/simulation/methods/instabilities.py
+++ b/AeViz/simulation/methods/instabilities.py
@@ -15,6 +15,7 @@ imported into the Simulation class.
 
 @get_grid
 @smooth
+@finite_differences
 def BV_frequency(self, file_name, mode=1, **kwargs):
     """
     Returns the Brunt-Vaisala frequency at specific timestep.
@@ -49,6 +50,7 @@ def BV_frequency(self, file_name, mode=1, **kwargs):
 
 @get_grid
 @smooth
+@finite_differences
 def convective_velocity(self, file_name, **kwargs):
     """
     Returns the convective velocity at specific timestep. Defined as
@@ -67,6 +69,7 @@ def convective_velocity(self, file_name, **kwargs):
 
 @get_grid
 @smooth
+@finite_differences
 def turbulent_velocity(self, file_name, **kwargs):
     """
     Returns the turbulent velocity at specific timestep. Defined as
@@ -92,6 +95,7 @@ def turbulent_velocity(self, file_name, **kwargs):
 
 @get_grid
 @smooth
+@finite_differences
 def convective_flux(self, file_name, **kwargs):
     """
     Returns the convective flux at specific timestep. Defined as
@@ -109,6 +113,7 @@ def convective_flux(self, file_name, **kwargs):
 
 @get_grid
 @smooth
+@finite_differences
 def Rossby_number(self, file_name, lenghtscale=True, **kwargs):
     """
     Returns the Rossby number at specific timestep. Defined as
@@ -132,6 +137,7 @@ def Rossby_number(self, file_name, lenghtscale=True, **kwargs):
 
 @get_grid
 @smooth
+@finite_differences
 def epicyclic_frequency(self, file_name, **kwargs):
     """
     Returns the epicyclic frequency at specific timestep. Defined as

--- a/AeViz/simulation/methods/magnetic_fields.py
+++ b/AeViz/simulation/methods/magnetic_fields.py
@@ -25,6 +25,7 @@ def __CT_magnetic_fields(self, file_name, **kwargs):
 
 @get_grid
 @smooth
+@finite_differences
 @hdf_isopen
 def magnetic_fields(self, file_name, comp:Literal['all', 'r', 'th', 'ph']='all',
                     **kwargs):
@@ -54,6 +55,7 @@ def magnetic_fields(self, file_name, comp:Literal['all', 'r', 'th', 'ph']='all',
 @mask_points
 @smooth
 @derive
+@finite_differences
 def poloidal_magnetic_fields(self, file_name, **kwargs):
     Br, Btheta, _ = self.magnetic_fields(file_name)
     data = np.sqrt(Br ** 2 + Btheta ** 2)
@@ -65,6 +67,7 @@ def poloidal_magnetic_fields(self, file_name, **kwargs):
 @mask_points
 @smooth
 @derive
+@finite_differences
 def toroidal_magnetic_fields(self, file_name, **kwargs):
     _, _, Bphi = self.magnetic_fields(file_name)
     return Bphi
@@ -72,6 +75,7 @@ def toroidal_magnetic_fields(self, file_name, **kwargs):
 @get_grid
 @mask_points
 @smooth
+@finite_differences
 def magnetic_energy(self, file_name, comp: Literal['all', 'tot', 'pol', 'tor']='all',
                     **kwargs):
     """
@@ -103,6 +107,7 @@ def stream_function(self, file_name, plane):
 @get_grid
 @mask_points
 @smooth
+@finite_differences
 @derive
 def alfven_velocity(self, file_name, **kwargs):
     """

--- a/AeViz/simulation/methods/thermo.py
+++ b/AeViz/simulation/methods/thermo.py
@@ -15,6 +15,7 @@ imported into the Simulation class.
 @mask_points
 @smooth
 @derive
+@finite_differences
 @hdf_isopen
 def gas_pressure(self, file_name, **kwargs):
     data =  self.ghost.remove_ghost_cells(np.squeeze(
@@ -27,6 +28,7 @@ def gas_pressure(self, file_name, **kwargs):
 @mask_points
 @smooth
 @derive
+@finite_differences
 @hdf_isopen
 def temperature(self, file_name, **kwargs):
     data = self.ghost.remove_ghost_cells(np.squeeze(
@@ -39,6 +41,7 @@ def temperature(self, file_name, **kwargs):
 @mask_points
 @smooth
 @derive
+@finite_differences
 @hdf_isopen
 def enthalpy(self, file_name, **kwargs):
     data = self.ghost.remove_ghost_cells(np.squeeze(
@@ -51,6 +54,7 @@ def enthalpy(self, file_name, **kwargs):
 @mask_points
 @smooth
 @derive
+@finite_differences
 @hdf_isopen
 def entropy(self, file_name, **kwargs):
     data = self.ghost.remove_ghost_cells(np.squeeze(
@@ -63,6 +67,7 @@ def entropy(self, file_name, **kwargs):
 @mask_points
 @smooth
 @derive
+@finite_differences
 @hdf_isopen
 def adiabatic_index(self, file_name, **kwargs):
     data = self.ghost.remove_ghost_cells(np.squeeze(
@@ -76,6 +81,7 @@ def adiabatic_index(self, file_name, **kwargs):
 @mask_points
 @smooth
 @derive
+@finite_differences
 @hdf_isopen
 def lorentz(self, file_name, **kwargs):
     data = self.ghost.remove_ghost_cells(np.squeeze(
@@ -88,6 +94,7 @@ def lorentz(self, file_name, **kwargs):
 @mask_points
 @smooth
 @derive
+@finite_differences
 @hdf_isopen
 def gravitational_potential(self, file_name, **kwargs):
     data = np.squeeze(
@@ -103,6 +110,7 @@ def gravitational_potential(self, file_name, **kwargs):
 @get_grid
 @mask_points
 @smooth
+@finite_differences
 @derive
 def gravitational_energy(self, file_name, **kwargs):
     data = 0.5 * self.rho(file_name) * \
@@ -114,6 +122,7 @@ def gravitational_energy(self, file_name, **kwargs):
 @get_grid
 @mask_points
 @smooth
+@finite_differences
 @derive
 def lapse_function(self, file_name, **kwargs):
     if self.lapse_form == 1:
@@ -135,6 +144,7 @@ def lapse_function(self, file_name, **kwargs):
 @mask_points
 @smooth
 @derive
+@finite_differences
 @hdf_isopen
 def internal_energy(self, file_name, **kwargs):
     data = self.ghost.remove_ghost_cells(np.squeeze(
@@ -146,6 +156,7 @@ def internal_energy(self, file_name, **kwargs):
 @get_grid
 @mask_points
 @smooth
+@finite_differences
 @derive
 def specific_internal_energy(self, file_name, **kwargs):
     data = self.internal_energy(file_name) / self.rho(file_name)
@@ -158,6 +169,7 @@ def specific_internal_energy(self, file_name, **kwargs):
 @mask_points
 @smooth
 @derive
+@finite_differences
 @hdf_isopen
 def nu_heat(self, file_name, **kwargs):
     data = self.ghost.remove_ghost_cells(np.squeeze(

--- a/AeViz/utils/decorators/simulation.py
+++ b/AeViz/utils/decorators/simulation.py
@@ -187,7 +187,7 @@ def finite_differences(func):
             data = [data]
         for i, dd in enumerate(data):
             ## Save the labels
-            lab = merge_strings(r'$\frac{\delta$', dd.label, r'$}{$', dd.label, r'$}$')
+            lab = merge_strings(r'$\frac{\delta $', dd.label, r'$}{$', dd.label, r'$}$')
             name = 'diff_' + dd.name
             if kwargs['mode'] == 'shell':
                 ## Get radial shell averages


### PR DESCRIPTION
NEW FEATURE:

It is now possible to compute the normalized differences in a quantity by adding the keywords:

- `diff=True`
- `mode=['shell', 'edges']`
`shell`: computes the difference between the cell and the averaged value in a spherical shell
`edges`: computes the difference between the cell value and the averaged one in the 27 neighbors 