### PR TITLE
Added spectrogram filters

### DIFF
--- a/AeViz/quantities_plotting/plotting.py
+++ b/AeViz/quantities_plotting/plotting.py
@@ -524,7 +524,7 @@ class Plotting(PlottingUtils, Data):
         data = self._Data__get_data_from_name(qt, **kwargs)
         keep_kwargs = {}
         for nm in ['window_size', 'check_spacing', 'time_range', 'scale_to',
-                   'windowing', 'overlap']:
+                   'windowing', 'overlap', 'highpass', 'lowpass', 'bandpass']:
             if nm in kwargs:
                 keep_kwargs[nm] = kwargs[nm]
         spectrogram = data.stft(**keep_kwargs)

--- a/AeViz/quantities_plotting/plotting_helpers.py
+++ b/AeViz/quantities_plotting/plotting_helpers.py
@@ -355,7 +355,9 @@ def remove_labelling(data, no_nu):
                        ',max', ',min', ',avg', ',tot', ', max', ', min', ', avg',
                        ', tot', ',x', ',y', ',z', ', x', ', y', ', z', ',r',
                        r',\theta', r',\phi', r', \theta', r', \phi', ', r',
-                       ',pol', ',tor', ', pol', ', tor']
+                       r'_{+,eq}', r'_{+,pol}', r'_{\times,eq}', r'_{\times,pol}',
+                       ',pol', ',tor', ', pol', ', tor',
+                       ]
     for symb in remove_symbols:
         new_label = new_label.replace(symb, '')
 

--- a/AeViz/units/aeseries.py
+++ b/AeViz/units/aeseries.py
@@ -4,7 +4,7 @@ import numpy as np
 from AeViz.units import u
 from AeViz.utils.files.string_utils import apply_symbol, merge_strings
 import numpy as np
-import scipy.signal 
+import scipy.signal
 import warnings
 from typing import Literal
 from AeViz.utils.math_utils import IDL_derivative
@@ -557,7 +557,8 @@ class aeseries:
     def stft(self, window_size=aerray(10, u.ms), check_spacing=False,
              time_range=None, scale_to:Literal['magnitude', 'psd']='magnitude',
              windowing:Literal['bartlett', 'blackman', 'hamming', 'hanning',
-                                'kaiser']='hanning', overlap=0.5):
+                                'kaiser']='hanning', overlap=0.5,
+             highpass=None, lowpass=None, bandpass=None):
         """
         Returns an aeseries with the short time fourier transform of the signal.
         Time is necessary to perform this.
@@ -574,8 +575,17 @@ class aeseries:
         scale_to{'magnitude', 'psd'} default magnitude. Each STFT column
                 represents either a 'magnitude' or a power spectral
                 density ('psd') spectrum
+        filters are avaiable: lowpass, highpass and bandpass
         returns the absolute value of the fft
         """
+        def butter_filter(signal, fs, cutoff, btype, order=4):
+            nyquist = 0.5 * fs
+            normal_cutoff = np.array(cutoff) / nyquist
+            b, a = scipy.signal.butter(order, normal_cutoff, btype=btype,
+                                       analog=False)
+            signal[:] = scipy.signal.filtfilt(b, a, signal.value)
+            return signal
+        
         if 'time' not in self.__axis_names:
             raise AttributeError("aeseries does not have the time attribute.")
         if self.time.shape != self.data.shape:
@@ -601,9 +611,19 @@ class aeseries:
         hop = int(overlap * win_len)
         window = getattr(np, windowing)(win_len)
         fs = 1 / np.mean(np.diff(self.time[indices].to(u.s).value))
+        signal = self.data[indices].copy()
+        if highpass is not None:
+            signal = butter_filter(signal, cutoff=highpass, fs=fs, btype='high')
+        if lowpass is not None:
+            signal = butter_filter(signal, cutoff=lowpass, fs=fs, btype='low')
+            print(signal)
+        if isinstance(bandpass, list):
+            if len(bandpass) == 2:
+                signal = butter_filter(signal, cutoff=bandpass, fs=fs,
+                                       btype='band')
         SFT = scipy.signal.ShortTimeFFT(window, hop, fs, scale_to=scale_to)
         freq = SFT.f
-        Zxx = np.abs(SFT.stft(self.data.value[indices]))
+        Zxx = np.abs(SFT.stft(signal.value))
         tm = SFT.t(len(self.time)) + self.time[0].value
         ffreq = aerray(freq, u.Hz, 'frequency', r'$f$', None, [0, 2000])
         ttm = aerray(tm, u.s, self.time.name, self.time.label,

--- a/AeViz/units/aeseries.py
+++ b/AeViz/units/aeseries.py
@@ -616,7 +616,6 @@ class aeseries:
             signal = butter_filter(signal, cutoff=highpass, fs=fs, btype='high')
         if lowpass is not None:
             signal = butter_filter(signal, cutoff=lowpass, fs=fs, btype='low')
-            print(signal)
         if isinstance(bandpass, list):
             if len(bandpass) == 2:
                 signal = butter_filter(signal, cutoff=bandpass, fs=fs,

--- a/AeViz/utils/physics/GW_utils.py
+++ b/AeViz/utils/physics/GW_utils.py
@@ -80,11 +80,11 @@ def GW_strain_3D(data, distance):
         time=time.copy())
     hD_cr_e = aeseries(
         aerray(const * IDL_derivative( data[:,2], hD_cr_e ), u.cm, 'hxeq',
-               r'$\mathcal{D}h_{x,eq}$', 'Spectral_r', [-150, 150]),
+               r'$\mathcal{D}h_{\times,eq}$', 'Spectral_r', [-150, 150]),
         time=time.copy())
     hD_cr_p = aeseries(
         aerray(const * IDL_derivative( data[:,2], hD_cr_p ), u.cm, 'hxpol',
-               r'$\mathcal{D}h_{x,pol}$', 'Spectral_r', [-150, 150]),
+               r'$\mathcal{D}h_{\times,pol}$', 'Spectral_r', [-150, 150]),
         time=time.copy())
     GWs = [hD_pl_e, hD_pl_p, hD_cr_e, hD_cr_p]
     if distance:
@@ -226,8 +226,8 @@ def GWs_energy_per_frequency_3D(GWs, time_range=None, windowing='hanning'):
     names = ['dE_df_h+eq', 'dE_df_h+pol', 'dE_df_hxeq', 'dE_df_hxpol']
     labels = [r'$\frac{\mathrm{d}E}{\mathrm{d}f}_\mathrm{+,eq}$',
               r'$\frac{\mathrm{d}E}{\mathrm{d}f}_\mathrm{+,pol}$',
-              r'$\frac{\mathrm{d}E}{\mathrm{d}f}_\mathrm{+,pol}$',
-              r'$\frac{\mathrm{d}E}{\mathrm{d}f}_\mathrm{x,pol}$']
+              r'$\frac{\mathrm{d}E}{\mathrm{d}f}_\mathrm{\times,pol}$',
+              r'$\frac{\mathrm{d}E}{\mathrm{d}f}_\mathrm{\times,pol}$']
     for i, GW in enumerate(GWs):
         spectro = GW.rfft(norm='forward', time_range=time_range,
                        windowing=windowing)
@@ -285,8 +285,8 @@ def characteristic_strain_3D(GWs, time_range, windowing, distance,
     names = ['hchar+eq', 'hchar+pol', 'hcharxeq', 'hcharxpol']
     labels = [r'$h_\mathrm{char,+,eq}$',
               r'$h_\mathrm{char,+,pol}$',
-              r'$h_\mathrm{char,x,eq}$',
-              r'$h_\mathrm{char,x,pol}$']
+              r'$h_\mathrm{char,\times,eq}$',
+              r'$h_\mathrm{char,\times,pol}$']
     if divide_by_frequency:
         labels = [merge_strings(lb, r'$\sqrt{f}$') for lb in labels]
     hchar = []


### PR DESCRIPTION
NEW FEATURE:
The spectrogram now support hig, low and band pass filters.
Just add the `highpass=value` or `lowpass=value` or `bandpass=[value1, value2]` when calling the method.